### PR TITLE
Removed uid for updateGroup in GroupDaoI.ts

### DIFF
--- a/interfaces/group/GroupDaoI.ts
+++ b/interfaces/group/GroupDaoI.ts
@@ -10,7 +10,7 @@ export default interface GroupDaoI {
 
     findAllGroupsForUser(uid: string): Promise<Group[]>;
 
-    updateGroup(uid: string, gid: string, group:Group): Promise<any>;
+    updateGroup(gid: string, group:Group): Promise<any>;
 
     deleteGroup(uid: string, gid: string): Promise<any>;
 


### PR DESCRIPTION
updateGroup in GroupDao does not need to have user uid to be able to update group properly. In the controller a check will happen to confirm the user making the update is an admin.